### PR TITLE
Fix naming

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,8 +4,11 @@ site :opscode
 
 # Locking version of the python cookbook that uses setuptools instead of distribute
 cookbook 'python',
-   :git => 'https://github.com/opscode-cookbooks/python.git',
-   :ref => '345c56acefdd8670938cd7d29a19fc5394aad9fc'
+    :git => 'https://github.com/comandrei/python.git',
+    :ref => '2cc384b5d996ca8b701826af265334bda40d0201'
+#   :git => 'https://github.com/poise/python.git',
+#   :ref => '8ce88cd17b0d6c64e948f1580815b5884b3c0f26'
+
 cookbook 'apt'
 cookbook 'yum'
 
@@ -16,7 +19,7 @@ cookbook 'nginx',
    :ref => 'd7a41ce15b30f91df95195b213d95bb9b3a6c4c3'
 
 cookbook 'supervisor',
-   :git => 'https://github.com/opscode-cookbooks/supervisor.git',
-   :ref => '3bcf67b4541554a013c2d5a99ac204eb33fd9dd4'
+   :git => 'https://github.com/poise/supervisor.git',
+   :ref => 'ffd88b59e3df97613b9ecfd53d489f6715551755'
 
 metadata

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,11 @@ Vagrant.configure("2") do |config|
   # option to your ~/.vagrant.d/Vagrantfile file
   config.berkshelf.enabled = true
 
+
   config.vm.provision :chef_solo do |chef|
+
+    chef.log_level = :debug
+
     chef.json = {
       :ipynb => {
          :NotebookApp => {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,11 +13,11 @@ default[:ipynb][:linux_user] = "ipynb"
 default[:ipynb][:linux_group] = "ipynb"
 
 # Home directory for the system user
-default[:ipynb][:home_dir] = File.join("/home/", default[:ipynb][:linux_user])
+default[:ipynb][:home_dir] = nil #File.join("/home/", default[:ipynb][:linux_user])
 
 # Spot to store the notebook files
-default[:ipynb][:notebook_dir] = File.join(default[:ipynb][:home_dir],
-                                           "notebooks")
+default[:ipynb][:notebook_dir] = nil #File.join(default[:ipynb][:home_dir],
+                                     #      "notebooks")
 
 default[:supervisor][:version] = "3.0"
 
@@ -26,11 +26,6 @@ default[:ipynb][:service_name] = "ipynb"
 
 # IPython profile
 default[:ipynb][:profile_name] = "cooked"
-
-# IPython directory for settings
-default[:ipynb][:ipython_settings_dir] = File.join(default[:ipynb][:home_dir],
-                                                   ".ipython")
-
 
 default[:ipynb][:proxy][:enable] = true
 default[:ipynb][:proxy][:hostname] = fqdn
@@ -116,7 +111,7 @@ default[:ipynb][:NotebookApp][:webapp_settings][:static_url_prefix] = nil
 ################################################################################
 
 # Where to store the virtual environment IPython runs in
-default[:ipynb][:virtenv] = File.join(default[:ipynb][:home_dir], ".ipyvirt")
+default[:ipynb][:virtenv] = nil #File.join(default[:ipynb][:home_dir], ".ipyvirt")
 
 # Version of Python to use
 default[:ipynb][:py_version] = "python2.7"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,44 +145,38 @@ default[:ipynb][:system_packages] = %w{
 # The scientific computing stack, installed in order
 # Note that numpy must be first and the dependencies for matplotlib also have
 # to start first due to the way numpy+matplotlib are packaged
-default[:ipynb][:scientific_stack] = ["numpy",
-                                      "freetype-py",
-                                      "pillow",
-                                      "scipy==0.12.1",
+default[:ipynb][:scientific_stack] = ["numpy==1.8.0",
+                                      "freetype-py==0.4.1",
+                                      "pillow==2.3.0",
+                                      "scipy==0.13.2",
                                       "python-dateutil",
                                       "pytz==2013b",
-                                      "six",
-                                      "scikit-learn",
-                                      "pandas",
-                                      "matplotlib",
-                                      "pygments",
-                                      "readline",
-                                      "nose",
-                                      "pexpect",
-                                      "cython",
-                                      "networkx",
-                                      "numexpr",
-                                      "tables",
-                                      "patsy",
-                                      "statsmodels",
-                                      "sympy",
-                                      "scikit-image",
-                                      "h5py",
-                                      "nltk",
-                                      "theano",
-                                      "xlrd",
-                                      "xlwt"
+                                      "six==1.5.2",
+                                      "scikit-learn==0.14.1",
+                                      "pandas==0.12.0",
+                                      "matplotlib==1.3.1",
+                                      "pygments==1.6",
+                                      "readline==6.2.4.1",
+                                      "nose==1.3.0",
+                                      "pexpect==3.0",
+                                      "cython==0.19.2",
+                                      "networkx==1.8.1",
+                                      "numexpr==2.2.2",
+                                      "tables==3.0.0",
+                                      "patsy==0.2.1",
+                                      "statsmodels==0.5.0",
+                                      "sympy==0.7.4.1",
+                                      "scikit-image==0.9.3",
+                                      "h5py==2.2.1",
+                                      "nltk==2.0.4",
+                                      "theano==0.6.0",
+                                      "xlrd==0.9.2",
+                                      "xlwt==0.7.5"
                                      ]
 
 # Let users configure exactly what version of IPython they are going to pull (from git, PyPI, etc.)
 # Most of the attributes, configuration, etc. rely on IPython 1.0 so be wary if for some reason you want to use 0.x releases.
-default[:ipynb][:ipython_package] = "ipython"
-
-# All the dependencies for IPython + IPython notebook
-default[:ipynb][:ipython_deps] = ["tornado==3.1",
-                                  "pyzmq",
-                                  "jinja2"
-]
+default[:ipynb][:ipython_package] = "ipython[notebook]==1.1.0"
 
 # Additional packages to install into the same virtualenv as the IPython notebook
 default[:ipynb][:extra_packages] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,20 @@
 
 include_recipe "python"
 
+# Unless the paths got overridden, we set them up here
+if node[:ipynb][:home_dir].nil? || node[:ipynb][:home_dir].empty?
+    node.set[:ipynb][:home_dir] = File.join("/home/", node[:ipynb][:linux_user])
+end
+
+if node[:ipynb][:notebook_dir].nil? || node[:ipynb][:notebook_dir].empty?
+    node.set[:ipynb][:notebook_dir] = File.join(node[:ipynb][:home_dir],
+                                            "notebooks")
+end
+
+if node[:ipynb][:virtenv].nil? || node[:ipynb][:virtenv].empty?
+    node.set[:ipynb][:virtenv] = File.join(node[:ipynb][:home_dir], ".ipyvirt")
+end
+
 # Make the package manager handle an initial install so that we
 # have system dependencies, whether we run IPython from site-packages or a
 # virtualenv.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,16 +59,6 @@ node[:ipynb][:scientific_stack].each do |pkg|
    end
 end
 
-# IPython notebook dependencies
-node[:ipynb][:ipython_deps].each do |pkg|
-   python_pip pkg do
-      virtualenv node[:ipynb][:virtenv]
-      user node[:ipynb][:linux_user]
-      group node[:ipynb][:linux_group]
-      action :install
-   end
-end
-
 # IPython proper
 python_pip node[:ipynb][:ipython_package] do
    virtualenv node[:ipynb][:virtenv]

--- a/recipes/virtenv_launch.rb
+++ b/recipes/virtenv_launch.rb
@@ -22,6 +22,8 @@
 
 include_recipe "supervisor"
 
+ipython_settings_dir = File.join(node[:ipynb][:home_dir], ".ipython")
+
 # Create the directory for storing notebooks
 directory node[:ipynb][:notebook_dir] do
    owner node[:ipynb][:linux_user]
@@ -35,14 +37,14 @@ ipynb_profile 'default' do
    action :create
    owner node[:ipynb][:linux_user]
    ipython_path "#{node[:ipynb][:virtenv]}/bin/ipython"
-   ipython_settings_dir node[:ipynb][:ipython_settings_dir]
+   ipython_settings_dir ipython_settings_dir
 end
 
 ipynb_profile node[:ipynb][:profile_name] do
    action :create
    owner node[:ipynb][:linux_user]
    ipython_path "#{node[:ipynb][:virtenv]}/bin/ipython"
-   ipython_settings_dir node[:ipynb][:ipython_settings_dir]
+   ipython_settings_dir ipython_settings_dir
 end
 
 ipynb_mathjax "MathJax!" do
@@ -53,7 +55,7 @@ ipynb_mathjax "MathJax!" do
                          "site-packages/IPython/html/static/mathjax")
 end
 
-profile_dir = File.join(node[:ipynb][:ipython_settings_dir],
+profile_dir = File.join(ipython_settings_dir,
                         "profile_" + node[:ipynb][:profile_name])
 
 nb_config = File.join(profile_dir, "ipython_notebook_config.py")

--- a/resources/profile.rb
+++ b/resources/profile.rb
@@ -29,5 +29,5 @@ end
 
 attribute :owner, :regex => [ /^([a-z]|[A-Z]|[0-9]|_|-)+$/, /^\d+$/ ], :default => node[:ipynb][:linux_user]
 attribute :ipython_path, :kind_of => String, :default => "#{node[:ipynb][:virtenv]}/bin/ipython"
-attribute :ipython_settings_dir, :kind_of => String, :default => node[:ipynb][:ipython_settings_dir]
+attribute :ipython_settings_dir, :kind_of => String
 


### PR DESCRIPTION
This PR
- Deals with the virtualenv & pip issues that are [fixed in a PR on the python cookbook](https://github.com/poise/python/pull/72) that hasn't been merged into the official yet
- Fixes a naming issue
  - Setting `node[:ipynb][:linux_user]` to something other than ipynb did not result in updating the install path for the virtualenv, etc.
- Pins dependencies for packages
