### PR TITLE
Update dependencies for ipynb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,9 +7,9 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
 
 depends "python"
-depends "yum", "~> 2.3.0"
-depends "apt", "~> 2.0.0"
-depends "supervisor", "~> 0.4.5"
-depends "nginx", "~> 1.7.0"
+depends "yum", ">= 2.3.0"
+depends "apt", ">= 2.0.0"
+depends "supervisor", ">= 0.4.5"
+depends "nginx", ">= 1.7.0"
 
 supports 'ubuntu'


### PR DESCRIPTION
The attached PR makes the dependencies optimistic (>=) vs. pessimistic (~>). Some of the listed dependencies, particularly apt, are a bit crufty and are causing conflicts in my use cases. I've done some preliminary testing with optimistic matching and am not encountering any issues, though updating to current versions of the various cookbooks and re-locking in pessimistically would probably not be a bad idea.

Thanks for the cookbook!
