### PR TITLE
Fix for mathjax install

### DIFF
--- a/providers/mathjax.rb
+++ b/providers/mathjax.rb
@@ -39,9 +39,8 @@ def install_mathjax(install_dir, ipython_path, owner)
 
        code <<-EOH
 from IPython.external.mathjax import install_mathjax
-install_mathjax(replace=True, dest='#{install_dir}')
+install_mathjax(tag='2.2.0', replace=True, dest='#{install_dir}')
        EOH
    end
 
 end
-


### PR DESCRIPTION
I noticed today that chef runs were failing to install MathJax with the following trace:

```
---- Begin output of "python"  "/tmp/chef-script20140806-5812-rinob6" ----
STDOUT: Downloading mathjax source from https://github.com/mathjax/MathJax/archive/v2.2.tar.gz
STDERR: Traceback (most recent call last):
  File "/tmp/chef-script20140806-5812-rinob6", line 2, in <module>
    install_mathjax(replace=True, dest='/home/ipynb/.ipyvirt/lib/python2.7/site-packages/IPython/html/static/mathjax')
  File "/home/ipynb/.ipyvirt/local/lib/python2.7/site-packages/IPython/external/mathjax.py", line 174, in install_mathjax
    response = urlopen(mathjax_url)
  File "/usr/lib/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 410, in open
    response = meth(req, response)
  File "/usr/lib/python2.7/urllib2.py", line 523, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python2.7/urllib2.py", line 442, in error
    result = self._call_chain(*args)
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 629, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib/python2.7/urllib2.py", line 410, in open
    response = meth(req, response)
  File "/usr/lib/python2.7/urllib2.py", line 523, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python2.7/urllib2.py", line 448, in error
    return self._call_chain(*args)
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 531, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 404: Not Found
---- End output of "python"  "/tmp/chef-script20140806-5812-rinob6" ----
Ran "python"  "/tmp/chef-script20140806-5812-rinob6" returned 1
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout.rb:257:in `invalid!'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout.rb:244:in `error!'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/mixin/shell_out.rb:43:in `shell_out!'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider/execute.rb:60:in `block in action_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/mixin/why_run.rb:52:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/mixin/why_run.rb:52:in `add_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider.rb:155:in `converge_by'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider/execute.rb:59:in `action_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider/script.rb:38:in `action_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/provider.rb:120:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource.rb:637:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:49:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:81:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/resource_collection.rb:96:in `execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/runner.rb:80:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:345:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:431:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:213:in `block in run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:207:in `fork'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/client.rb:207:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application.rb:217:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/solo.rb:221:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/solo.rb:213:in `loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application/solo.rb:213:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/lib/chef/application.rb:67:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.8/bin/chef-solo:25:in `<top (required)>'
/usr/bin/chef-solo:23:in `load'
/usr/bin/chef-solo:23:in `<main>'
```

I don't know what changed, maybe GitHub was being nice and had logic that would redirect you to the correct release based on some sort of logic, but that logic appears to be gone.  Luckily the [install_mathjax](https://github.com/ipython/ipython/blob/rel-2.1.0/IPython/external/mathjax.py#L139) allows for us to specify a tag, which will fix the issue.
