### PR TITLE
Adding nginx config to address websocket connection issue.

### DIFF
--- a/templates/default/nginx-proxy.erb
+++ b/templates/default/nginx-proxy.erb
@@ -33,6 +33,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
+        proxy_set_header Origin "";
     }
 
 }


### PR DESCRIPTION
Based on this stackoverflow post: http://stackoverflow.com/questions/22665809/how-to-configure-ipython-behind-nginx-in-a-subpath this nginx config allows browsers to properly communicate with the ipython noteboook server via websockets.
