### PR TITLE
Enabling customized notebook config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,6 +106,12 @@ default[:ipynb][:NotebookApp][:base_project_url] = nil
 default[:ipynb][:NotebookApp][:base_kernel_url] = nil
 default[:ipynb][:NotebookApp][:webapp_settings][:static_url_prefix] = nil
 
+
+# Any additional configuration for Notebooks, to complete
+# ipython_notebook_config.py ruby template
+default[:ipynb][:NotebookApp][:additional_config] = nil
+
+
 ################################################################################
 # Virtualenv
 ################################################################################

--- a/templates/default/ipython_notebook_config.py.erb
+++ b/templates/default/ipython_notebook_config.py.erb
@@ -60,3 +60,11 @@ c.NotebookApp.password = '<%= node[:ipynb][:NotebookApp][:password_hash] %>'
 <% end %>
 
 c.NotebookApp.webapp_settings = {'static_url_prefix':'/static/'}
+
+#
+# Adding whatever content you feel like to the notebook config file. You
+# have to make sure it does not interfere with parameters already covered
+# in ipython_notebook_config.py ruby template.
+#
+
+<%= node[:ipynb][:NotebookApp][:additional_config] %>


### PR DESCRIPTION
Adding the possibility to add some customizable options into Notebook configuration.

Usage example (in attributes/default.rb)

```
# Additionnal configuration 
default[:ipynb][:NotebookApp][:additional_config] = <<-eos 
c.IPKernelApp.exec_files = [ 
    "#{File.join(default[:ipynb][:home_dir], "my_fancy_lib"}"
] 
eos 
```